### PR TITLE
fix: ir_datasets_loader.py

### DIFF
--- a/application/src/django_admin/settings.py
+++ b/application/src/django_admin/settings.py
@@ -275,6 +275,7 @@ else:
     else:
         raise PermissionError(f"Can not write to {ld} in production mode.")
 
+
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 

--- a/application/src/django_admin/settings.py
+++ b/application/src/django_admin/settings.py
@@ -18,10 +18,6 @@ import yaml
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 custom_settings = {}
-if next((BASE_DIR / "config").glob("*.yml"), None) is None:
-    raise RuntimeError(
-        "No configuration file found. Did you run `make setup`?"
-    )
 for cfg in (BASE_DIR / "config").glob("*.yml"):
     custom_settings.update(yaml.load(open(cfg, "r").read(), Loader=yaml.FullLoader))
 

--- a/application/src/tira/ir_datasets_loader.py
+++ b/application/src/tira/ir_datasets_loader.py
@@ -31,7 +31,7 @@ class IrDatasetsLoader(object):
         queries_mapped_jsonl = [self.map_query_as_jsonl(query, include_original) for query in dataset.queries_iter()]
         queries_mapped_xml = [self.map_query_as_xml(query, include_original) for query in dataset.queries_iter()]
         qrels_mapped = [self.map_qrel(qrel) for qrel in dataset.qrels_iter()]
-        
+
         self.write_lines_to_file(docs_mapped, output_dataset_path/"documents.jsonl")
         self.write_lines_to_file(queries_mapped_jsonl, output_dataset_path/"queries.jsonl")
         self.write_lines_to_xml_file(ir_datasets_id, queries_mapped_xml, output_dataset_path/"queries.xml")
@@ -68,7 +68,7 @@ class IrDatasetsLoader(object):
 
         @param doc: the document as a namedtuple
         @param include_original: flag which signals if the original document data should be stored too
-        :return ret: the mapped document
+        :return ret: the mapped document 
         """
         ret = {
             "docno": doc.doc_id,
@@ -83,7 +83,6 @@ class IrDatasetsLoader(object):
     def map_query_as_jsonl(self, query: tuple, include_original=False) -> str:
         ret = {
             "qid": query.query_id,
-            # TODO: change when .default_text() is implemented
             #"query": query.default_text()
             "query": query.text,
         }

--- a/application/src/tira/ir_datasets_loader.py
+++ b/application/src/tira/ir_datasets_loader.py
@@ -19,7 +19,7 @@ class IrDatasetsLoader(object):
     def load_dataset_for_fullrank(self, ir_datasets_id: str, output_dataset_path: Path, output_dataset_truth_path: Path,  include_original=False) -> None:
         """ Loads a dataset through the ir_datasets package by the given ir_datasets ID.
         Maps documents, queries, qrels to a standardized format in preparation for full-rank operations with PyTerrier.
-
+        
         @param ir_datasets_id: the dataset ID as of ir_datasets
         @param output_dataset_path: the path to the directory where the output files will be stored
         @param output_dataset_truth_path: the path to the directory where the output files will be stored

--- a/application/src/tira/ir_datasets_loader.py
+++ b/application/src/tira/ir_datasets_loader.py
@@ -19,7 +19,7 @@ class IrDatasetsLoader(object):
     def load_dataset_for_fullrank(self, ir_datasets_id: str, output_dataset_path: Path, output_dataset_truth_path: Path,  include_original=False) -> None:
         """ Loads a dataset through the ir_datasets package by the given ir_datasets ID.
         Maps documents, queries, qrels to a standardized format in preparation for full-rank operations with PyTerrier.
-        
+
         @param ir_datasets_id: the dataset ID as of ir_datasets
         @param output_dataset_path: the path to the directory where the output files will be stored
         @param output_dataset_truth_path: the path to the directory where the output files will be stored
@@ -57,7 +57,7 @@ class IrDatasetsLoader(object):
         rerank = (self.construct_rerank_row(dataset, docs, id_pair[0], id_pair[1]) for id_pair in id_pairs)
 
         qrels_mapped = (self.map_qrel(qrel) for qrel in dataset.qrels_iter())
-
+        
         self.write_lines_to_file(rerank, output_dataset_path/"rerank.jsonl")
         self.write_lines_to_file(qrels_mapped, output_dataset_truth_path/"qrels.txt")
 

--- a/application/src/tira/ir_datasets_loader.py
+++ b/application/src/tira/ir_datasets_loader.py
@@ -23,7 +23,7 @@ class IrDatasetsLoader(object):
         @param ir_datasets_id: the dataset ID as of ir_datasets
         @param output_dataset_path: the path to the directory where the output files will be stored
         @param output_dataset_truth_path: the path to the directory where the output files will be stored
-        @param include_original {False}: flag which signals if the original data of documents and queries should be included
+        @param include_original {False}: flag which signals if the original data of documents and queries should be included 
         """
         dataset = self.load_irds(ir_datasets_id)
 
@@ -31,7 +31,7 @@ class IrDatasetsLoader(object):
         queries_mapped_jsonl = [self.map_query_as_jsonl(query, include_original) for query in dataset.queries_iter()]
         queries_mapped_xml = [self.map_query_as_xml(query, include_original) for query in dataset.queries_iter()]
         qrels_mapped = [self.map_qrel(qrel) for qrel in dataset.qrels_iter()]
-
+        
         self.write_lines_to_file(docs_mapped, output_dataset_path/"documents.jsonl")
         self.write_lines_to_file(queries_mapped_jsonl, output_dataset_path/"queries.jsonl")
         self.write_lines_to_xml_file(ir_datasets_id, queries_mapped_xml, output_dataset_path/"queries.xml")

--- a/application/src/tira/management/commands/ir_datasets_loader_cli.py
+++ b/application/src/tira/management/commands/ir_datasets_loader_cli.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
        @param --output_dataset_path: required, string: the path to the directory where the output will be stored
        @param --output_dataset_truth_path: required, string: the path to the directory where the output will be stored
        @param --include_original {False}: optional, boolean: flag to signal, if the original data should be included
-       @param --rerank: optional, string: if used, mapping will be in preparation for re-ranking operations and a path to file
+       @param --rerank: optional, string: if used, mapping will be in preparation for re-ranking operations and a path to file 
                         with TREC-run formatted data is required
     """
 
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if not self.contains_all_required_args(options):
             return
-
+        
         if options['rerank']:
             self.import_dataset_for_rerank(
                 options['ir_datasets_id'],

--- a/application/src/tira/management/commands/ir_datasets_loader_cli.py
+++ b/application/src/tira/management/commands/ir_datasets_loader_cli.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if not self.contains_all_required_args(options):
             return
-        
+
         if options['rerank']:
             self.import_dataset_for_rerank(
                 options['ir_datasets_id'],

--- a/application/src/tira/management/commands/ir_datasets_loader_cli.py
+++ b/application/src/tira/management/commands/ir_datasets_loader_cli.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if not self.contains_all_required_args(options):
             return
-
+        
         if options['rerank']:
             self.import_dataset_for_rerank(
                 options['ir_datasets_id'],

--- a/model/.gitignore
+++ b/model/.gitignore
@@ -1,3 +1,0 @@
-src/state/tira.sqlite3
-src/model/virtual-machines/admin.prototext
-src/model/virtual-machines/virtual-machines.txt


### PR DESCRIPTION
Imports BeautifulSoup 4.

Fixes the multiple use of generators by creating lists instead of generators: line 31 + 32.

Fixes the surprisingly odd behaviour of BeautifulSoup objects to lost all their content whenever they're appended to another soup tree. Using deep copies of these objects instead with python's copy module: line 162.

Tested it and now it seems to work just fine!